### PR TITLE
added fixes for heroku SPA support

### DIFF
--- a/client/src/Auth/auth0-variables.js
+++ b/client/src/Auth/auth0-variables.js
@@ -1,5 +1,5 @@
 export const AUTH_CONFIG = {
   domain: 'midwaste.auth0.com',
   clientId: '2o5Whwo8daNgkGgpGT17ZOxUOOIMNgS6',
-  callbackUrl: (process.env.NODE_ENV === 'production') ? 'http://midwatse.herokuapp.com/callback' : 'http://localhost:3000/callback'
+  callbackUrl: (process.env.NODE_ENV === 'production') ? 'https://midwaste.herokuapp.com/callback' : 'http://localhost:3000/callback'
 }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "project 3",
   "main": "server.js",
   "scripts": {
-    "start": "if-env NODE_ENV=production && yarn start:prod || yarn start:dev",
-    "start:prod": "npm run server",
-    "start:dev": "concurrently \"npm run watch\" \"npm run client\"",
-    "watch": "nodemon ./bin/www",
-    "server": "node ./bin/www",
-    "heroku-postbuild": "cd client && yarn install && yarn build",
-    "client": "cd client && yarn start"
+    "client-install": "npm install --prefix client",
+    "start": "node ./bin/www",
+    "server": "nodemon ./bin/www",
+    "client": "npm start --prefix client",
+    "dev": "concurrently \"npm run server\" \"npm run client\"",
+    "heroku-postbuild": "NPM_CONFIG_PRODUCION=false npm install --prefix client && npm run build --prefix client"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -4,16 +4,13 @@ const logger = require('morgan');
 const mongoose = require('mongoose');
 const path = require('path');
 
-const server = express();
-
-// Serve static files from the React app
-server.use(express.static(path.join(__dirname, 'client/build')));
+const app = express();
 
 // Middleware
-server.use(logger('dev'));
-server.use(cookieParser());
-server.use(express.json());
-server.use(express.urlencoded({ extended: false }));
+app.use(logger('dev'));
+app.use(cookieParser());
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 
 // Mongoose Connection
 const MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost/midWaste";
@@ -21,19 +18,22 @@ mongoose.connect(MONGODB_URI, { useNewUrlParser: true });
 
 // Routes
 const apiRouter = require('./routes/api');
-server.use('/api', apiRouter);
+app.use('/api', apiRouter);
 
-// The "catchall" handler: for any request that doesn't
-// match one above, send back React's index.html file.
-server.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname+'/client/build/index.html'));
-});
+if (process.env.NODE_ENV === 'production') {
+  // Serve static files from the React app
+  app.use(express.static('client/build'));
+
+  app.get('*', (req, res) => {
+    res.sendFile(path.resolve(__dirname, 'client', 'build', 'index.html'));
+  })
+}
 
 // Error handler
-server.use(function(err, req, res) {
+app.use(function(err, req, res) {
   // Set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};
 });
 
-module.exports = server;
+module.exports = app;

--- a/static.json
+++ b/static.json
@@ -1,0 +1,6 @@
+{
+  "root": "client/build/",
+  "routes": {
+    "/**": "index.html"
+  }
+}


### PR DESCRIPTION
Solution for #35

#### What's new:
- Added `static.json` to tell Heroku to always serve the built `index.html`.
- Updated server to serve static files from `client/build` in production environments.
- Updated server `package.json` scripts to match the ones found [here](https://www.youtube.com/watch?v=71wSzpLyW9k) by Traversy Media.
    - These worked well in development and production so I'd recommend using them here.
- <b>Heroku:</b> Added [heroku static buildpack](https://github.com/hone/heroku-buildpack-static) (works in conjunction with the NodeJS buildpack).
- <b>Auth0:</b> Updated allowed callback urls to use `https` (low priority)
